### PR TITLE
Fix installaction when using the "user" flatpak_method

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,20 +1,20 @@
 ---
 # Configure flatpak
 
-- name: Add the flathub flatpak repository remote to the user installation
+- name: "Add flathub flatpak repository remote to {{ flatpak_method }} installation"
   flatpak_remote:
     name: flathub
     state: present
     flatpakrepo_url: "{{ item }}"
     method: "{{ flatpak_method }}"
-  become: true
+  become: "{{ 'yes' if flatpak_method == 'system' else 'no' }}"
   loop: "{{ flatpak_repos }}"
 
-- name: install packages for current user
+- name: "install packages for {{ flatpak_method }}"
   flatpak:
     name: "{{ item }}"
     state: present
     method: "{{ flatpak_method }}"
-  become: true
+  become: "{{ 'yes' if flatpak_method == 'system' else 'no' }}"
   loop: "{{ flatpak_packages }}"
   poll: 0


### PR DESCRIPTION
Set "become: yes" only when using system flatpak method.
This fixes a problem where flatpaks are installed under the root
user, but not installed system-wide.